### PR TITLE
[MISC][SW] allow usage of non-default AWS profile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pgateway/common-services-api",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pgateway/common-services-api",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "license": "ISC",
       "dependencies": {
         "aws-sdk": "^2.1444.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@pgateway/common-services-api",
   "main": "dist/index.js",
   "type": "dist/index.d.ts",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Utility to connect to AWS API GW",
   "homepage": "https://github.com/pway123/pg-common-services-api",
   "repository": "github:pway123/pg-common-services-api",

--- a/src/util/CredentialsUtil.ts
+++ b/src/util/CredentialsUtil.ts
@@ -15,7 +15,7 @@ async function loadCredentials(CREDENTIAL_PROVIDER: TCredentialProvider): Promis
     const configs = { httpOptions: { timeout: 5000 }, maxRetries: 3 }
     const remoteProvider = () => new AWS.RemoteCredentials(configs);
     const ec2MetadataProvider = () => new AWS.EC2MetadataCredentials(configs);
-    const sharedIniFileProvider = () => new AWS.SharedIniFileCredentials({ profile: "default" });
+    const sharedIniFileProvider = () => new AWS.SharedIniFileCredentials();
     const enviromentProvider = () => new AWS.EnvironmentCredentials('AWS');
     const providers = [];
     const { awsContainerCredFullUri, awsContainerCredRelativeUri } = getEnvVars();


### PR DESCRIPTION
Devs might have a different AWS profile that is set as the default. So it would be good for this repo not to assume that the required AWS profile is always the default.

However, for our CI/CD environment, that is the convention. So our solution should make sure this remains the same.

By removing `{ profile: "default" }`, what the [AWS SDK](https://github.com/aws/aws-sdk-js/blob/6295de3ff138733c0f928d4735f16f9211c3bba9/lib/credentials/shared_ini_file_credentials.js#L84) will do is to use the profile given in `AWS_PROFILE` first, followed by the default.