### PR TITLE
Updated npm engine specifications

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pgateway/common-services-api",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pgateway/common-services-api",
-      "version": "2.5.1",
+      "version": "2.5.2",
       "license": "ISC",
       "dependencies": {
         "aws-sdk": "^2.1444.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "webpack-node-externals": "^3.0.0"
       },
       "engines": {
-        "node": "^20",
+        "node": ">=18",
         "npm": ">=9"
       }
     },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "dist"
   ],
   "engines": {
-    "node": "^20",
+    "node": ">=18",
     "npm": ">=9"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@pgateway/common-services-api",
   "main": "dist/index.js",
   "type": "dist/index.d.ts",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "Utility to connect to AWS API GW",
   "homepage": "https://github.com/pway123/pg-common-services-api",
   "repository": "github:pway123/pg-common-services-api",


### PR DESCRIPTION
**Changes:**
Updated the engines field in package.json to specify broader compatibility:
Node.js: Now supports version 18 and above (>=18).
npm: Now supports version 9 and above (>=9).

**Rationale:**
Flexibility: This change offers greater flexibility to users of this package, allowing it to be utilized with any future backward-compatible versions of Node.js and npm.
Reduced Maintenance: By supporting a range of versions, we reduce the frequency of updates required for engine compatibility.
